### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,19 @@
 extern crate gcc;
 
+#[cfg(not(target_env = "msvc"))]
 fn main() {
     gcc::Config::new()
                 .file("src/accumulate.c")
                 .flag("-march=native")
                 .flag("-std=c99")
+                .compile("libaccumulate.a");
+}
+
+#[cfg(target_env = "msvc")]
+fn main() {
+    gcc::Config::new()
+                .file("src/accumulate.c")
+                // Maximum optimizations
+                .flag("/Ox")
                 .compile("libaccumulate.a");
 }

--- a/src/accumulate.c
+++ b/src/accumulate.c
@@ -31,7 +31,7 @@ void accumulate_sse(const float *in, uint8_t *out, uint32_t n) {
     y = _mm_mul_ps(y, _mm_set1_ps(255.0f));
     __m128i z = _mm_cvtps_epi32(y);
     z = _mm_shuffle_epi8(z, mask);
-    _mm_store_ss((float *)&out[i], (__m128)z);
+    _mm_store_ss((float *)&out[i], _mm_castsi128_ps(z));
     offset = _mm_shuffle_ps(x, x, _MM_SHUFFLE(3, 3, 3, 3));
   }
 }


### PR DESCRIPTION
Just a few simple changes were required. MSVC doesn't know what `-std` or `-march` means, and you can't directly use a typecast for `__m128*` types, there's an intrinsic to do that cast. I tested this on the VS2015 compiler.
