### PR TITLE
impl Debug for FontError.

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -583,6 +583,7 @@ impl<I> Iterator for BezPathOps<I> where I: Iterator<Item=(bool, i16, i16)> {
     }
 }
 
+#[derive(Debug)]
 pub enum FontError {
     Invalid
 }


### PR DESCRIPTION
This is especially useful when parsing fonts and using .unwrap() to
panic on error – which is not uncommon for tests / tooling purposes.