### PR TITLE
Switch benches to use noto font

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-rs"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0"
 authors = [ "Raph Levien <raph@google.com>" ]
 keywords = ["font", "truetype", "ttf"]

--- a/benches/glyph.rs
+++ b/benches/glyph.rs
@@ -19,15 +19,11 @@ extern crate test;
 use font_rs::font;
 use test::Bencher;
 
-use std::fs::File;
-use std::io::Read;
+static FONT_DATA: &'static [u8] =
+    include_bytes!("../fonts/notomono-hinted/NotoMono-Regular.ttf");
 
 fn glyphbench(b: &mut Bencher, size: u32) {
-    let filename = "misc/wt024.ttf";
-    let mut file = File::open(filename).unwrap();
-    let mut data = Vec::new();
-    file.read_to_end(&mut data).unwrap();
-    let font = font::parse(&data).unwrap();
+    let font = font::parse(&FONT_DATA).unwrap();
     b.iter(|| font.render_glyph(6000, size));
 }
 

--- a/benches/glyph.rs
+++ b/benches/glyph.rs
@@ -24,7 +24,7 @@ static FONT_DATA: &'static [u8] =
 
 fn glyphbench(b: &mut Bencher, size: u32) {
     let font = font::parse(&FONT_DATA).unwrap();
-    b.iter(|| font.render_glyph(6000, size));
+    b.iter(|| font.render_glyph(200, size));
 }
 
 #[bench]

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,4 +1,0 @@
-# wt024.ttf
-
-The file was copied from https://github.com/dictcp/wangfonts/blob/master/TrueType/wt024.ttf and is used in benches only.
-The file is released under GNU GPL 2.


### PR DESCRIPTION
Also include the font data with include_bytes!() so it will work when cross-compiling.