### PR TITLE
Allow optionally compiling with no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,7 @@ description = "A font renderer written (mostly) in pure, safe Rust"
 repository = "https://github.com/google/font-rs"
 
 [features]
+default = ["std"]
+
 sse = []
+std = []

--- a/src/accumulate.rs
+++ b/src/accumulate.rs
@@ -75,18 +75,12 @@ pub fn accumulate(src: &[f32]) -> Vec<u8> {
 
 #[cfg(not(feature = "sse"))]
 pub fn accumulate(src: &[f32]) -> Vec<u8> {
-    #[cfg(not(feature = "std"))]
-    use core::intrinsics::fabsf32;
-
-    #[cfg(feature = "std")]
-    use std::intrinsics::fabsf32;
-
-    let mut acc = 0.0;
-    src.iter()
-        .map(|c| {
+    let mut acc = 0.0f32;
+    src.into_iter()
+        .map(|&c| {
             // This would translate really well to SIMD
             acc += c;
-            let y = unsafe { fabsf32(acc) };
+            let y = acc.abs();
             let y = if y < 1.0 { y } else { 1.0 };
             (255.0 * y) as u8
         })
@@ -101,8 +95,8 @@ mod tests {
     //  accumulate fn
     fn accumulate_simple_impl(src: &[f32]) -> Vec<u8> {
         let mut acc = 0.0;
-        src.iter()
-            .map(|c| {
+        src.into_iter()
+            .map(|&c| {
                 acc += c;
                 let y = acc.abs();
                 let y = if y < 1.0 { y } else { 1.0 };

--- a/src/float32.rs
+++ b/src/float32.rs
@@ -1,0 +1,28 @@
+
+use core::intrinsics::*;
+
+/// Abstraction for floating point intrinsics in no_std mode
+pub trait Float32 {
+    fn abs(self) -> f32;
+    fn floor(self) -> f32;
+    fn ceil(self) -> f32;
+    fn sqrt(self) -> f32;
+}
+
+impl Float32 for f32 {
+    fn abs(self) -> f32 {
+        unsafe { fabsf32(self) }
+    }
+
+    fn floor(self) -> f32 {
+        unsafe { floorf32(self) }
+    }
+
+    fn ceil(self) -> f32 {
+        unsafe { ceilf32(self) }
+    }
+
+    fn sqrt(self) -> f32 {
+        unsafe { sqrtf32(self) }
+    }
+}

--- a/src/font.rs
+++ b/src/font.rs
@@ -15,12 +15,6 @@
 //! A simple renderer for TrueType fonts
 
 #[cfg(not(feature = "std"))]
-use core::intrinsics;
-
-#[cfg(feature = "std")]
-use std::intrinsics;
-
-#[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -42,6 +36,9 @@ use std::fmt::{Debug, Display, Formatter};
 
 use geom::{affine_pt, Affine, Point};
 use raster::Raster;
+
+#[cfg(not(feature = "std"))]
+use float32::Float32;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct Tag(u32);
@@ -725,10 +722,10 @@ impl<'a> Font<'a> {
     ) -> (Metrics, Affine) {
         let ppem = self.head.units_per_em();
         let scale = (size as f32) / (ppem as f32);
-        let l = unsafe { intrinsics::floorf32(xmin as f32 * scale) } as i32;
-        let t = unsafe { intrinsics::floorf32(ymax as f32 * -scale) } as i32;
-        let r = unsafe { intrinsics::ceilf32(xmax as f32 * scale) } as i32;
-        let b = unsafe { intrinsics::ceilf32(ymin as f32 * -scale) } as i32;
+        let l = (xmin as f32 * scale).floor() as i32;
+        let t = (ymax as f32 * -scale).floor() as i32;
+        let r = (xmax as f32 * scale).ceil() as i32;
+        let b = (ymin as f32 * -scale).ceil() as i32;
         let metrics = Metrics {
             l: l,
             t: t,

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -14,6 +14,10 @@
 
 //! Geometry primitive data structures and manipulations
 
+#[cfg(not(feature = "std"))]
+use alloc::fmt::{Debug, Formatter, Result};
+
+#[cfg(feature = "std")]
 use std::fmt::{Debug, Formatter, Result};
 
 #[derive(Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! A very high performance font renderer.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(alloc, core_intrinsics)]
+#![cfg_attr(not(feature = "std"), feature(alloc, core_intrinsics))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]
@@ -27,3 +27,6 @@ pub mod accumulate;
 pub mod font;
 pub mod geom;
 pub mod raster;
+
+#[cfg(not(feature = "std"))]
+mod float32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,13 @@
 
 //! A very high performance font renderer.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(alloc, core_intrinsics)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 #[macro_use]
 pub mod macros;
 pub mod accumulate;

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -14,7 +14,14 @@
 
 //! An antialiased rasterizer for quadratic Beziers
 
-use std::cmp::min;
+#[cfg(not(feature = "std"))]
+use core::intrinsics;
+
+#[cfg(feature = "std")]
+use std::intrinsics;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 use accumulate::accumulate;
 use geom::Point;
@@ -32,6 +39,18 @@ pub struct Raster {
 // TODO: is there a faster way? (investigate whether approx recip is good enough)
 fn recip(x: f32) -> f32 {
     x.recip()
+}
+
+fn fsqrt32(f: f32) -> f32 {
+    unsafe { intrinsics::sqrtf32(f) }
+}
+
+fn floor32(f: f32) -> f32 {
+    unsafe { intrinsics::floorf32(f) }
+}
+
+fn ceil32(f: f32) -> f32 {
+    unsafe { intrinsics::ceilf32(f) }
 }
 
 impl Raster {
@@ -59,15 +78,16 @@ impl Raster {
         if p0.y < 0.0 {
             x -= p0.y * dxdy;
         }
-        for y in y0..min(self.h, p1.y.ceil() as usize) {
+        let ymin = self.h.min(ceil32(p1.y) as usize);
+        for y in y0..ymin {
             let linestart = y * self.w;
             let dy = ((y + 1) as f32).min(p1.y) - (y as f32).max(p0.y);
             let xnext = x + dxdy * dy;
             let d = dy * dir;
             let (x0, x1) = if x < xnext { (x, xnext) } else { (xnext, x) };
-            let x0floor = x0.floor();
+            let x0floor = floor32(x0);
             let x0i = x0floor as i32;
-            let x1ceil = x1.ceil();
+            let x1ceil = ceil32(x1);
             let x1i = x1ceil as i32;
             if x1i <= x0i + 1 {
                 let xmf = 0.5 * (x + xnext) - x0floor;
@@ -107,7 +127,7 @@ impl Raster {
             return;
         }
         let tol = 3.0;
-        let n = 1 + (tol * (devx * devx + devy * devy)).sqrt().sqrt().floor() as usize;
+        let n = 1 + fsqrt32(fsqrt32(tol * (devx * devx + devy * devy))) as usize;
         //println!("n = {}", n);
         let mut p = *p0;
         let nrecip = recip(n as f32);


### PR DESCRIPTION
This is the first time I've messed with conditional no_std, so I'm sure there are cleaner ways to get some of this stuff. Very open to suggestions - I'd like to try using this myself.

~~I only learned after writing this that there's a no_std-safe math crate which provides safe floating point wrappers, so it might be worth pulling that in to get rid of all these unsafe intrinsics calls.~~

I also changed the font "tables" structure from a HashMap to a BTreeMap simply because BTreeMap exists in `alloc`. I wonder, though, if the map structure is needed at all. It looks like it's not actually used outside of the `parse` constructor, so perhaps that for-loop should just be rewritten to find and set aside each table as it goes?